### PR TITLE
removed 'name' variable and purged all references in util.go and contracts.go

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,12 @@ sudo apt-get install texlive-xetex
 # initaite a new contract
 claw new john examples/templates/consultant.md
 
+# change into the newly generated directory
+cd john
+
 # edit the params
-vim john/params.toml
+vim params.toml
 
 # compile the markdown and output a final pdf using pandoc
-claw compile --output pdf john
+claw compile --output pdf
 ```

--- a/contracts.go
+++ b/contracts.go
@@ -1,109 +1,109 @@
 package main
 
 import (
-  "bytes"
-  "crypto/sha256"
-  "fmt"
-  "io/ioutil"
-  "os"
-  "os/exec"
-  "path/filepath"
-  "regexp"
-  "strings"
-  "text/template"
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"text/template"
 
-  "github.com/spf13/cobra"
+	"github.com/spf13/cobra"
 )
 
 var (
-  EXHIBIT_PREFIX = "exhibit."
-  SIGN_PREFIX    = "sign."
-  VALUE_SUFFIX   = ".value"
+	EXHIBIT_PREFIX = "exhibit."
+	SIGN_PREFIX    = "sign."
+	VALUE_SUFFIX   = ".value"
 
-  VARIABLE_REGEX = regexp.MustCompile(`{{\s*([\w\._-]+)\s*}}`)
+	VARIABLE_REGEX = regexp.MustCompile(`{{\s*([\w\._-]+)\s*}}`)
 )
 
 type ContractTemplate struct {
-  TemplateHash string
-  Vars         []string
-  Exhibits     []string
-  Signing      []string
+	TemplateHash string
+	Vars         []string
+	Exhibits     []string
+	Signing      []string
 }
 
 // return list of all variables and exhibits found in contract template
 func parseTemplate(b []byte) ContractTemplate {
-  var contractTemplate ContractTemplate
-  matches := VARIABLE_REGEX.FindAllStringSubmatch(string(b), -1)
-  for _, m := range matches {
-    match := m[1]
+	var contractTemplate ContractTemplate
+	matches := VARIABLE_REGEX.FindAllStringSubmatch(string(b), -1)
+	for _, m := range matches {
+		match := m[1]
 
-    if strings.HasPrefix(match, EXHIBIT_PREFIX) {
-      exhibitName := strings.TrimPrefix(match, EXHIBIT_PREFIX)
-      // only append if it doesn't have .value
-      if !strings.HasSuffix(exhibitName, VALUE_SUFFIX) {
-        contractTemplate.Exhibits = appendNew(contractTemplate.Exhibits, exhibitName)
-      }
-    } else if strings.HasPrefix(match, SIGN_PREFIX) {
-      signName := strings.TrimPrefix(match, SIGN_PREFIX)
-      contractTemplate.Signing = appendNew(contractTemplate.Signing, signName)
-    } else {
-      contractTemplate.Vars = appendNew(contractTemplate.Vars, match)
-    }
-  }
-  return contractTemplate
+		if strings.HasPrefix(match, EXHIBIT_PREFIX) {
+			exhibitName := strings.TrimPrefix(match, EXHIBIT_PREFIX)
+			// only append if it doesn't have .value
+			if !strings.HasSuffix(exhibitName, VALUE_SUFFIX) {
+				contractTemplate.Exhibits = appendNew(contractTemplate.Exhibits, exhibitName)
+			}
+		} else if strings.HasPrefix(match, SIGN_PREFIX) {
+			signName := strings.TrimPrefix(match, SIGN_PREFIX)
+			contractTemplate.Signing = appendNew(contractTemplate.Signing, signName)
+		} else {
+			contractTemplate.Vars = appendNew(contractTemplate.Vars, match)
+		}
+	}
+	return contractTemplate
 }
 
 // copy the template into a new dir and instantiate params file with empty values
 func newContract(cmd *cobra.Command, args []string) error {
-  if len(args) != 2 {
-    return fmt.Errorf("new expects two args: directory for new engagement and template path")
-  }
+	if len(args) != 2 {
+		return fmt.Errorf("new expects two args: directory for new engagement and template path")
+	}
 
-  engagementPath, tmplPath := args[0], args[1]
+	engagementPath, tmplPath := args[0], args[1]
 
-  b, err := ioutil.ReadFile(tmplPath)
-  if err != nil {
-    return err
-  }
+	b, err := ioutil.ReadFile(tmplPath)
+	if err != nil {
+		return err
+	}
 
-  // get list of variables for a blank config file
-  tmpl := parseTemplate(b)
+	// get list of variables for a blank config file
+	tmpl := parseTemplate(b)
 
-  // compute hash of template
-  h := sha256.New()
-  h.Write(b)
-  templateHash := h.Sum(nil)
-  tmpl.TemplateHash = fmt.Sprintf("%X", templateHash)
+	// compute hash of template
+	h := sha256.New()
+	h.Write(b)
+	templateHash := h.Sum(nil)
+	tmpl.TemplateHash = fmt.Sprintf("%X", templateHash)
 
-  // make the directory and copy over the template
-  if err := os.MkdirAll(engagementPath, 0700); err != nil {
-    return err
-  }
+	// make the directory and copy over the template
+	if err := os.MkdirAll(engagementPath, 0700); err != nil {
+		return err
+	}
 
-  if err := ioutil.WriteFile(filepath.Join(engagementPath, "template.md"), b, 0600); err != nil {
-    return err
-  }
+	if err := ioutil.WriteFile(filepath.Join(engagementPath, "template.md"), b, 0600); err != nil {
+		return err
+	}
 
-  paramsFile := generateParamsFile(tmpl)
+	paramsFile := generateParamsFile(tmpl)
 
-  // write the params file
-  return ioutil.WriteFile(filepath.Join(engagementPath, "params.toml"), paramsFile, 0600)
+	// write the params file
+	return ioutil.WriteFile(filepath.Join(engagementPath, "params.toml"), paramsFile, 0600)
 }
 
 func generateParamsFile(tmpl ContractTemplate) []byte {
-  var paramsFileTemplate *template.Template
-  var err error
-  var buffer bytes.Buffer
+	var paramsFileTemplate *template.Template
+	var err error
+	var buffer bytes.Buffer
 
-  paramsFileTemplate, err = template.New("paramsFile").Parse(paramsFileDefault)
-  if err != nil {
-    panic(err)
-  }
+	paramsFileTemplate, err = template.New("paramsFile").Parse(paramsFileDefault)
+	if err != nil {
+		panic(err)
+	}
 
-  if err := paramsFileTemplate.Execute(&buffer, tmpl); err != nil {
-    panic(err)
-  }
-  return buffer.Bytes()
+	if err := paramsFileTemplate.Execute(&buffer, tmpl); err != nil {
+		panic(err)
+	}
+	return buffer.Bytes()
 }
 
 const paramsFileDefault = `# This is a TOML file containing parameters for this contract
@@ -129,93 +129,93 @@ template = "{{ .TemplateHash}}"
 
 func compileContract(cmd *cobra.Command, args []string) error {
 
-  // load the params from toml file
-  params, err := loadConfig()
-  if err != nil {
-    return err
-  }
+	// load the params from toml file
+	params, err := loadConfig()
+	if err != nil {
+		return err
+	}
 
-  // read the contract template
-  b, err := ioutil.ReadFile("template.md")
-  if err != nil {
-    return err
-  }
+	// read the contract template
+	b, err := ioutil.ReadFile("template.md")
+	if err != nil {
+		return err
+	}
 
-  tmpl := parseTemplate(b)
-  exhibits := tmpl.Exhibits
+	tmpl := parseTemplate(b)
+	exhibits := tmpl.Exhibits
 
-  // substitute params into template holes
-  var missingParams []string
-  markdownOutput := VARIABLE_REGEX.ReplaceAllFunc(b, func(in []byte) []byte {
-    paramName := strings.TrimSuffix(strings.TrimPrefix(string(in), "{{"), "}}")
+	// substitute params into template holes
+	var missingParams []string
+	markdownOutput := VARIABLE_REGEX.ReplaceAllFunc(b, func(in []byte) []byte {
+		paramName := strings.TrimSuffix(strings.TrimPrefix(string(in), "{{"), "}}")
 
-    // if its an exhibit, we replace it with the exhibit number.
-    // if its a var, we replace it with its value
-    if strings.HasPrefix(paramName, EXHIBIT_PREFIX) {
-      exhibitName := strings.TrimPrefix(paramName, EXHIBIT_PREFIX)
+		// if its an exhibit, we replace it with the exhibit number.
+		// if its a var, we replace it with its value
+		if strings.HasPrefix(paramName, EXHIBIT_PREFIX) {
+			exhibitName := strings.TrimPrefix(paramName, EXHIBIT_PREFIX)
 
-      if strings.HasSuffix(exhibitName, VALUE_SUFFIX) {
-        exhibitName = strings.TrimSuffix(exhibitName, VALUE_SUFFIX)
-        for _, e := range exhibits {
-          if exhibitName == e {
-            exhibitValue := params.GetString("exhibit." + exhibitName)
-            if exhibitValue != "" {
-              return []byte(exhibitValue)
-            }
-          }
-        }
-      } else {
-        for i, e := range exhibits {
-          if exhibitName == e {
-            return []byte(fmt.Sprintf("Exhibit %d", i+1))
-          }
-        }
-      }
-    } else if strings.HasPrefix(paramName, SIGN_PREFIX) {
-      signName := strings.TrimPrefix(paramName, SIGN_PREFIX)
-      paramVal := params.GetString("sign." + signName)
-      if paramVal != "" {
-        return []byte(paramVal)
-      }
-    } else {
-      paramVal := params.GetString("var." + paramName)
-      if paramVal != "" {
-        return []byte(paramVal)
-      }
-    }
+			if strings.HasSuffix(exhibitName, VALUE_SUFFIX) {
+				exhibitName = strings.TrimSuffix(exhibitName, VALUE_SUFFIX)
+				for _, e := range exhibits {
+					if exhibitName == e {
+						exhibitValue := params.GetString("exhibit." + exhibitName)
+						if exhibitValue != "" {
+							return []byte(exhibitValue)
+						}
+					}
+				}
+			} else {
+				for i, e := range exhibits {
+					if exhibitName == e {
+						return []byte(fmt.Sprintf("Exhibit %d", i+1))
+					}
+				}
+			}
+		} else if strings.HasPrefix(paramName, SIGN_PREFIX) {
+			signName := strings.TrimPrefix(paramName, SIGN_PREFIX)
+			paramVal := params.GetString("sign." + signName)
+			if paramVal != "" {
+				return []byte(paramVal)
+			}
+		} else {
+			paramVal := params.GetString("var." + paramName)
+			if paramVal != "" {
+				return []byte(paramVal)
+			}
+		}
 
-    missingParams = append(missingParams, paramName)
-    return []byte("----")
-  })
+		missingParams = append(missingParams, paramName)
+		return []byte("----")
+	})
 
-  // error if params is missing anything
-  if len(missingParams) > 0 {
-    return fmt.Errorf("Missing params: %v", missingParams)
-  }
+	// error if params is missing anything
+	if len(missingParams) > 0 {
+		return fmt.Errorf("Missing params: %v", missingParams)
+	}
 
-  switch outputType {
-  case "md":
-    if err := ioutil.WriteFile("contract.md", markdownOutput, 0600); err != nil {
-      return err
-    }
-  case "html":
-    htmlOutput := markdown2html(markdownOutput)
-    if err := ioutil.WriteFile("contract.html", htmlOutput, 0600); err != nil {
-      return err
-    }
-  case "pdf":
-    // requires the md to be written
-    mdPath := "contract.md"
-    if err := ioutil.WriteFile(mdPath, markdownOutput, 0600); err != nil {
-      return err
-    }
-    cmd := exec.Command("pandoc", mdPath, "--latex-engine=xelatex", "-o", "contract.pdf")
-    cmd.Stdout = os.Stdout
-    cmd.Stderr = os.Stderr
-    return cmd.Run()
-  default:
-    return fmt.Errorf("Unknown output format: %v", outputType)
-  }
+	switch outputType {
+	case "md":
+		if err := ioutil.WriteFile("contract.md", markdownOutput, 0600); err != nil {
+			return err
+		}
+	case "html":
+		htmlOutput := markdown2html(markdownOutput)
+		if err := ioutil.WriteFile("contract.html", htmlOutput, 0600); err != nil {
+			return err
+		}
+	case "pdf":
+		// requires the md to be written
+		mdPath := "contract.md"
+		if err := ioutil.WriteFile(mdPath, markdownOutput, 0600); err != nil {
+			return err
+		}
+		cmd := exec.Command("pandoc", mdPath, "--latex-engine=xelatex", "-o", "contract.pdf")
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		return cmd.Run()
+	default:
+		return fmt.Errorf("Unknown output format: %v", outputType)
+	}
 
-  return nil
+	return nil
 }

--- a/contracts.go
+++ b/contracts.go
@@ -1,109 +1,109 @@
 package main
 
 import (
-	"bytes"
-	"crypto/sha256"
-	"fmt"
-	"io/ioutil"
-	"os"
-	"os/exec"
-	"path/filepath"
-	"regexp"
-	"strings"
-	"text/template"
+  "bytes"
+  "crypto/sha256"
+  "fmt"
+  "io/ioutil"
+  "os"
+  "os/exec"
+  "path/filepath"
+  "regexp"
+  "strings"
+  "text/template"
 
-	"github.com/spf13/cobra"
+  "github.com/spf13/cobra"
 )
 
 var (
-	EXHIBIT_PREFIX = "exhibit."
-	SIGN_PREFIX    = "sign."
-	VALUE_SUFFIX   = ".value"
+  EXHIBIT_PREFIX = "exhibit."
+  SIGN_PREFIX    = "sign."
+  VALUE_SUFFIX   = ".value"
 
-	VARIABLE_REGEX = regexp.MustCompile(`{{\s*([\w\._-]+)\s*}}`)
+  VARIABLE_REGEX = regexp.MustCompile(`{{\s*([\w\._-]+)\s*}}`)
 )
 
 type ContractTemplate struct {
-	TemplateHash string
-	Vars         []string
-	Exhibits     []string
-	Signing      []string
+  TemplateHash string
+  Vars         []string
+  Exhibits     []string
+  Signing      []string
 }
 
 // return list of all variables and exhibits found in contract template
 func parseTemplate(b []byte) ContractTemplate {
-	var contractTemplate ContractTemplate
-	matches := VARIABLE_REGEX.FindAllStringSubmatch(string(b), -1)
-	for _, m := range matches {
-		match := m[1]
+  var contractTemplate ContractTemplate
+  matches := VARIABLE_REGEX.FindAllStringSubmatch(string(b), -1)
+  for _, m := range matches {
+    match := m[1]
 
-		if strings.HasPrefix(match, EXHIBIT_PREFIX) {
-			exhibitName := strings.TrimPrefix(match, EXHIBIT_PREFIX)
-			// only append if it doesn't have .value
-			if !strings.HasSuffix(exhibitName, VALUE_SUFFIX) {
-				contractTemplate.Exhibits = appendNew(contractTemplate.Exhibits, exhibitName)
-			}
-		} else if strings.HasPrefix(match, SIGN_PREFIX) {
-			signName := strings.TrimPrefix(match, SIGN_PREFIX)
-			contractTemplate.Signing = appendNew(contractTemplate.Signing, signName)
-		} else {
-			contractTemplate.Vars = appendNew(contractTemplate.Vars, match)
-		}
-	}
-	return contractTemplate
+    if strings.HasPrefix(match, EXHIBIT_PREFIX) {
+      exhibitName := strings.TrimPrefix(match, EXHIBIT_PREFIX)
+      // only append if it doesn't have .value
+      if !strings.HasSuffix(exhibitName, VALUE_SUFFIX) {
+        contractTemplate.Exhibits = appendNew(contractTemplate.Exhibits, exhibitName)
+      }
+    } else if strings.HasPrefix(match, SIGN_PREFIX) {
+      signName := strings.TrimPrefix(match, SIGN_PREFIX)
+      contractTemplate.Signing = appendNew(contractTemplate.Signing, signName)
+    } else {
+      contractTemplate.Vars = appendNew(contractTemplate.Vars, match)
+    }
+  }
+  return contractTemplate
 }
 
 // copy the template into a new dir and instantiate params file with empty values
 func newContract(cmd *cobra.Command, args []string) error {
-	if len(args) != 2 {
-		return fmt.Errorf("new expects two args: directory for new engagement and template path")
-	}
+  if len(args) != 2 {
+    return fmt.Errorf("new expects two args: directory for new engagement and template path")
+  }
 
-	engagementPath, tmplPath := args[0], args[1]
+  engagementPath, tmplPath := args[0], args[1]
 
-	b, err := ioutil.ReadFile(tmplPath)
-	if err != nil {
-		return err
-	}
+  b, err := ioutil.ReadFile(tmplPath)
+  if err != nil {
+    return err
+  }
 
-	// get list of variables for a blank config file
-	tmpl := parseTemplate(b)
+  // get list of variables for a blank config file
+  tmpl := parseTemplate(b)
 
-	// compute hash of template
-	h := sha256.New()
-	h.Write(b)
-	templateHash := h.Sum(nil)
-	tmpl.TemplateHash = fmt.Sprintf("%X", templateHash)
+  // compute hash of template
+  h := sha256.New()
+  h.Write(b)
+  templateHash := h.Sum(nil)
+  tmpl.TemplateHash = fmt.Sprintf("%X", templateHash)
 
-	// make the directory and copy over the template
-	if err := os.MkdirAll(engagementPath, 0700); err != nil {
-		return err
-	}
+  // make the directory and copy over the template
+  if err := os.MkdirAll(engagementPath, 0700); err != nil {
+    return err
+  }
 
-	if err := ioutil.WriteFile(filepath.Join(engagementPath, "template.md"), b, 0600); err != nil {
-		return err
-	}
+  if err := ioutil.WriteFile(filepath.Join(engagementPath, "template.md"), b, 0600); err != nil {
+    return err
+  }
 
-	paramsFile := generateParamsFile(tmpl)
+  paramsFile := generateParamsFile(tmpl)
 
-	// write the params file
-	return ioutil.WriteFile(filepath.Join(engagementPath, "params.toml"), paramsFile, 0600)
+  // write the params file
+  return ioutil.WriteFile(filepath.Join(engagementPath, "params.toml"), paramsFile, 0600)
 }
 
 func generateParamsFile(tmpl ContractTemplate) []byte {
-	var paramsFileTemplate *template.Template
-	var err error
-	var buffer bytes.Buffer
+  var paramsFileTemplate *template.Template
+  var err error
+  var buffer bytes.Buffer
 
-	paramsFileTemplate, err = template.New("paramsFile").Parse(paramsFileDefault)
-	if err != nil {
-		panic(err)
-	}
+  paramsFileTemplate, err = template.New("paramsFile").Parse(paramsFileDefault)
+  if err != nil {
+    panic(err)
+  }
 
-	if err := paramsFileTemplate.Execute(&buffer, tmpl); err != nil {
-		panic(err)
-	}
-	return buffer.Bytes()
+  if err := paramsFileTemplate.Execute(&buffer, tmpl); err != nil {
+    panic(err)
+  }
+  return buffer.Bytes()
 }
 
 const paramsFileDefault = `# This is a TOML file containing parameters for this contract
@@ -128,99 +128,94 @@ template = "{{ .TemplateHash}}"
 //-----------------------------------------
 
 func compileContract(cmd *cobra.Command, args []string) error {
-	if len(args) != 1 {
-		return fmt.Errorf("compile expects one arg: name")
-	}
 
-	name := args[0]
+  // load the params from toml file
+  params, err := loadConfig()
+  if err != nil {
+    return err
+  }
 
-	// load the params from toml file
-	params, err := loadConfig(name)
-	if err != nil {
-		return err
-	}
+  // read the contract template
+  b, err := ioutil.ReadFile("template.md")
+  if err != nil {
+    return err
+  }
 
-	// read the contract template
-	b, err := ioutil.ReadFile(filepath.Join(name, "template.md"))
-	if err != nil {
-		return err
-	}
+  tmpl := parseTemplate(b)
+  exhibits := tmpl.Exhibits
 
-	tmpl := parseTemplate(b)
-	exhibits := tmpl.Exhibits
+  // substitute params into template holes
+  var missingParams []string
+  markdownOutput := VARIABLE_REGEX.ReplaceAllFunc(b, func(in []byte) []byte {
+    paramName := strings.TrimSuffix(strings.TrimPrefix(string(in), "{{"), "}}")
 
-	// substitute params into template holes
-	var missingParams []string
-	markdownOutput := VARIABLE_REGEX.ReplaceAllFunc(b, func(in []byte) []byte {
-		paramName := strings.TrimSuffix(strings.TrimPrefix(string(in), "{{"), "}}")
+    // if its an exhibit, we replace it with the exhibit number.
+    // if its a var, we replace it with its value
+    if strings.HasPrefix(paramName, EXHIBIT_PREFIX) {
+      exhibitName := strings.TrimPrefix(paramName, EXHIBIT_PREFIX)
 
-		// if its an exhibit, we replace it with the exhibit number.
-		// if its a var, we replace it with its value
-		if strings.HasPrefix(paramName, EXHIBIT_PREFIX) {
-			exhibitName := strings.TrimPrefix(paramName, EXHIBIT_PREFIX)
+      if strings.HasSuffix(exhibitName, VALUE_SUFFIX) {
+        exhibitName = strings.TrimSuffix(exhibitName, VALUE_SUFFIX)
+        for _, e := range exhibits {
+          if exhibitName == e {
+            exhibitValue := params.GetString("exhibit." + exhibitName)
+            if exhibitValue != "" {
+              return []byte(exhibitValue)
+            }
+          }
+        }
+      } else {
+        for i, e := range exhibits {
+          if exhibitName == e {
+            return []byte(fmt.Sprintf("Exhibit %d", i+1))
+          }
+        }
+      }
+    } else if strings.HasPrefix(paramName, SIGN_PREFIX) {
+      signName := strings.TrimPrefix(paramName, SIGN_PREFIX)
+      paramVal := params.GetString("sign." + signName)
+      if paramVal != "" {
+        return []byte(paramVal)
+      }
+    } else {
+      paramVal := params.GetString("var." + paramName)
+      if paramVal != "" {
+        return []byte(paramVal)
+      }
+    }
 
-			if strings.HasSuffix(exhibitName, VALUE_SUFFIX) {
-				exhibitName = strings.TrimSuffix(exhibitName, VALUE_SUFFIX)
-				for _, e := range exhibits {
-					if exhibitName == e {
-						exhibitValue := params.GetString("exhibit." + exhibitName)
-						if exhibitValue != "" {
-							return []byte(exhibitValue)
-						}
-					}
-				}
-			} else {
-				for i, e := range exhibits {
-					if exhibitName == e {
-						return []byte(fmt.Sprintf("Exhibit %d", i+1))
-					}
-				}
-			}
-		} else if strings.HasPrefix(paramName, SIGN_PREFIX) {
-			signName := strings.TrimPrefix(paramName, SIGN_PREFIX)
-			paramVal := params.GetString("sign." + signName)
-			if paramVal != "" {
-				return []byte(paramVal)
-			}
-		} else {
-			paramVal := params.GetString("var." + paramName)
-			if paramVal != "" {
-				return []byte(paramVal)
-			}
-		}
+    missingParams = append(missingParams, paramName)
+    return []byte("----")
+  })
 
-		missingParams = append(missingParams, paramName)
-		return []byte("----")
-	})
+  // error if params is missing anything
+  if len(missingParams) > 0 {
+    return fmt.Errorf("Missing params: %v", missingParams)
+  }
 
-	// error if params is missing anything
-	if len(missingParams) > 0 {
-		return fmt.Errorf("Missing params: %v", missingParams)
-	}
+  switch outputType {
+  case "md":
+    if err := ioutil.WriteFile("contract.md", markdownOutput, 0600); err != nil {
+      return err
+    }
+  case "html":
+    htmlOutput := markdown2html(markdownOutput)
+    if err := ioutil.WriteFile("contract.html", htmlOutput, 0600); err != nil {
+      return err
+    }
+  case "pdf":
+    // requires the md to be written
+    mdPath := "contract.md"
+    if err := ioutil.WriteFile(mdPath, markdownOutput, 0600); err != nil {
+      return err
+    }
+    cmd := exec.Command("pandoc", mdPath, "--latex-engine=xelatex", "-o", "contract.pdf")
+    cmd.Stdout = os.Stdout
+    cmd.Stderr = os.Stderr
+    return cmd.Run()
+  default:
+    return fmt.Errorf("Unknown output format: %v", outputType)
+  }
 
-	switch outputType {
-	case "md":
-		if err := ioutil.WriteFile(filepath.Join(name, "contract.md"), markdownOutput, 0600); err != nil {
-			return err
-		}
-	case "html":
-		htmlOutput := markdown2html(markdownOutput)
-		if err := ioutil.WriteFile(filepath.Join(name, "contract.html"), htmlOutput, 0600); err != nil {
-			return err
-		}
-	case "pdf":
-		// requires the md to be written
-		mdPath := filepath.Join(name, "contract.md")
-		if err := ioutil.WriteFile(mdPath, markdownOutput, 0600); err != nil {
-			return err
-		}
-		cmd := exec.Command("pandoc", mdPath, "--latex-engine=xelatex", "-o", filepath.Join(name, "contract.pdf"))
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		return cmd.Run()
-	default:
-		return fmt.Errorf("Unknown output format: %v", outputType)
-	}
-
-	return nil
+  return nil
 }

--- a/util.go
+++ b/util.go
@@ -1,37 +1,37 @@
 package main
 
 import (
-	"github.com/russross/blackfriday"
-	"github.com/spf13/viper"
+  "github.com/russross/blackfriday"
+  "github.com/spf13/viper"
 )
 
 // append to list if not in list already
 func appendNew(list []string, name string) []string {
-	found := false
-	for _, el := range list {
-		if el == name {
-			found = true
-		}
-	}
-	if !found {
-		list = append(list, name)
-	}
-	return list
+  found := false
+  for _, el := range list {
+    if el == name {
+      found = true
+    }
+  }
+  if !found {
+    list = append(list, name)
+  }
+  return list
 }
 
 // load params config
-func loadConfig(rootDir string) (*viper.Viper, error) {
-	config := viper.New()
-	config.SetConfigName("params")
-	config.SetConfigType("toml")
-	config.AddConfigPath(rootDir)
-	err := config.ReadInConfig()
-	if err != nil {
-		return nil, err
-	}
-	return config, nil
+func loadConfig() (*viper.Viper, error) {
+  config := viper.New()
+  config.SetConfigName("params")
+  config.SetConfigType("toml")
+  config.AddConfigPath(".")
+  err := config.ReadInConfig()
+  if err != nil {
+    return nil, err
+  }
+  return config, nil
 }
 
 func markdown2html(b []byte) []byte {
-	return blackfriday.MarkdownBasic(b)
+  return blackfriday.MarkdownBasic(b)
 }

--- a/util.go
+++ b/util.go
@@ -1,37 +1,37 @@
 package main
 
 import (
-  "github.com/russross/blackfriday"
-  "github.com/spf13/viper"
+	"github.com/russross/blackfriday"
+	"github.com/spf13/viper"
 )
 
 // append to list if not in list already
 func appendNew(list []string, name string) []string {
-  found := false
-  for _, el := range list {
-    if el == name {
-      found = true
-    }
-  }
-  if !found {
-    list = append(list, name)
-  }
-  return list
+	found := false
+	for _, el := range list {
+		if el == name {
+			found = true
+		}
+	}
+	if !found {
+		list = append(list, name)
+	}
+	return list
 }
 
 // load params config
 func loadConfig() (*viper.Viper, error) {
-  config := viper.New()
-  config.SetConfigName("params")
-  config.SetConfigType("toml")
-  config.AddConfigPath(".")
-  err := config.ReadInConfig()
-  if err != nil {
-    return nil, err
-  }
-  return config, nil
+	config := viper.New()
+	config.SetConfigName("params")
+	config.SetConfigType("toml")
+	config.AddConfigPath(".")
+	err := config.ReadInConfig()
+	if err != nil {
+		return nil, err
+	}
+	return config, nil
 }
 
 func markdown2html(b []byte) []byte {
-  return blackfriday.MarkdownBasic(b)
+	return blackfriday.MarkdownBasic(b)
 }


### PR DESCRIPTION
Now compiling is to be done in generated directories (changes reflected in README).  Primary reason being that if we're including a file path for a signature, it seems to make sense that it would be relative to the directory in which the params file exists (also, even if the signature method is changed, it still makes sense to me to work out of the specific directory to which you're making changes).